### PR TITLE
自己紹介マークダウンにYAML Front Matter追加

### DIFF
--- a/members/gosyujin.md
+++ b/members/gosyujin.md
@@ -1,3 +1,10 @@
+---
+layout: page
+title: "gosyujin"
+description: ""
+---
+{% include JB/setup %}
+
 # 自己紹介
 
 ![icon](https://avatars0.githubusercontent.com/u/588166?s=120)


### PR DESCRIPTION
meetupsのマークダウンファイルにYAML Front Matterを追加して
kawasaki.github.ioにmeetupsをサブモジュールとして追加すれば GitHub Page 上で Page としてみれますね。

```
$ cd kawasaki.github.io
$ git submodule add https://github.com/kawasakirb/meetups.git
```

![2014-06-26 14 48 16](https://cloud.githubusercontent.com/assets/588166/3395061/8ac0b536-fcf5-11e3-8a48-7d63aa75f192.png)
