### PR TITLE
Add 096 (Ruby 3.0 News)

### DIFF
--- a/ruby3-news/kawasakirb096.ipynb
+++ b/ruby3-news/kawasakirb096.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "69e73122-d809-4d2f-b52f-448050ac5820",
+   "metadata": {},
+   "source": [
+    "# プロと読み解く Ruby 3.0 NEWS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfc8ecef-5544-41aa-895b-e8228a1a6923",
+   "metadata": {},
+   "source": [
+    "### 式展開を含む文字列リテラルは、frozen-string-literal: true で freeze しなくなった"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db19de7a-fbdc-42c9-a1c4-47e9a5956566",
+   "metadata": {},
+   "source": [
+    "``` ruby\n",
+    "# frozen-string-literal: true\n",
+    "\n",
+    "p \"foo\".frozen? #=> true\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7390c2ec-652e-434c-9722-28140460eedd",
+   "metadata": {},
+   "source": [
+    "``` ruby\n",
+    "# frozen-string-literal: true\n",
+    "\n",
+    "p \"foo#{42}bar\".frozen? #=> true\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16c40c4-03c7-42dc-b126-746a30485dcf",
+   "metadata": {},
+   "source": [
+    "## 組み込みクラスのアップデート"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d80740d9-bc4f-4df0-8126-7aea7bdb2f7b",
+   "metadata": {},
+   "source": [
+    "### Array のサブクラスのメソッドが、サブクラスではなく、Array クラスのオブジェクトを返すようになった"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9e2706d2-7f69-4422-b255-f59b973c064b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2, 3]\n",
+      "Array\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Array"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class MyArray < Array\n",
+    "end\n",
+    "\n",
+    "ary = MyArray.new([1, 2, 3]).drop(1)\n",
+    "\n",
+    "p ary       #=> [2, 3]\n",
+    "p ary.class #=> MyArray  # 2.7\n",
+    "ary.class #=> Array    # 3.0"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Ruby 3.0.0",
+   "language": "ruby",
+   "name": "ruby-3.0.0"
+  },
+  "language_info": {
+   "file_extension": ".rb",
+   "mimetype": "application/x-ruby",
+   "name": "ruby",
+   "version": "3.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
「プロと読み解く Ruby 3.0 NEWS」を読みながら、今回から Jupyter に残すようにしました。